### PR TITLE
Feature/2 autofill weather from date

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# .env.example
+VITE_WEATHER_API_KEY=your_openweather_key_here

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
+.env

--- a/frontend/src/components/DateSelector.jsx
+++ b/frontend/src/components/DateSelector.jsx
@@ -1,27 +1,100 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
-import { ko } from "date-fns/locale";
+import axios from "axios";
 import { format } from "date-fns";
+import { ko } from "date-fns/locale";
 
-function DateSelector({ onDateSelect }) {
+function DateSelector({ onDateSelect, onWeatherFetch }) {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [showPicker, setShowPicker] = useState(false);
+  const [weatherCache, setWeatherCache] = useState({});
+  const [forecastList, setForecastList] = useState([]);
+  const [location, setLocation] = useState({ lat: null, lon: null });
+
+  // 🌍 컴포넌트 mount 시 현재 위치 가져오기
+  // 1. 위치 설정
+  useEffect(() => {
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setLocation({
+          lat: pos.coords.latitude,
+          lon: pos.coords.longitude,
+        });
+      },
+      (err) => {
+        console.warn("위치 정보를 가져오지 못했습니다:", err);
+        setLocation({ lat: 37.5665, lon: 126.978 });
+      }
+    );
+  }, []);
+
+  // 2. 위치가 설정된 후 날씨 가져오기
+  useEffect(() => {
+    if (location.lat && location.lon) {
+      fetchForecast();
+    }
+  }, [location]);
+
+  const fetchForecast = async () => {
+    try {
+      const VITE_WEATHER_API_KEY = import.meta.env.VITE_WEATHER_API_KEY;
+      const res = await axios.get(
+        "https://api.openweathermap.org/data/2.5/forecast/daily",
+        {
+          params: {
+            lat: location.lat || 37.5665, // 기본값: 서울
+            lon: location.lon || 126.978,
+            cnt: 16,
+            units: "metric",
+            appid: VITE_WEATHER_API_KEY,
+          },
+        }
+      );
+      console.log("📡 날씨 API 응답:", res.data); // ← 콘솔 출력 추가
+
+      setForecastList(res.data.list);
+    } catch (err) {
+      console.error("날씨 API 요청 실패:", err);
+    }
+  };
 
   const handleChange = (date) => {
     setSelectedDate(date);
     setShowPicker(false);
-    onDateSelect(date); // 부모에게 알림
+    onDateSelect(date);
+
+    const key = format(date, "yyyy-MM-dd");
+    if (weatherCache[key]) {
+      onWeatherFetch(weatherCache[key]); // 캐시 사용
+    } else {
+      const daysDiff = Math.floor(
+        (date.setHours(0, 0, 0, 0) - new Date().setHours(0, 0, 0, 0)) /
+          (1000 * 60 * 60 * 24)
+      );
+      const data = forecastList[daysDiff];
+      if (data) {
+        const weather = {
+          temperature: data.temp.day,
+          humidity: data.humidity,
+          windSpeed: data.speed,
+          rainfall: data.rain ?? 0,
+          snowfall: data.snow ?? 0,
+        };
+        setWeatherCache((prev) => ({ ...prev, [key]: weather }));
+        onWeatherFetch(weather);
+      }
+    }
   };
 
   return (
     <div style={{ marginBottom: "2rem" }}>
-      <span
+      <h1
         style={{ cursor: "pointer", fontWeight: "bold" }}
         onClick={() => setShowPicker(!showPicker)}
       >
         📅 {format(selectedDate, "yyyy년 MM월 dd일", { locale: ko })}
-      </span>
+      </h1>
       {showPicker && (
         <DatePicker
           selected={selectedDate}

--- a/frontend/src/components/DateSelector.jsx
+++ b/frontend/src/components/DateSelector.jsx
@@ -9,18 +9,16 @@ function DateSelector({ onDateSelect, onWeatherFetch }) {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [showPicker, setShowPicker] = useState(false);
   const [weatherCache, setWeatherCache] = useState({});
-  const [forecastList, setForecastList] = useState([]);
+  const [forecast5, setForecast5] = useState([]);
+  const [forecast16, setForecast16] = useState([]);
   const [location, setLocation] = useState({ lat: null, lon: null });
 
-  // 🌍 컴포넌트 mount 시 현재 위치 가져오기
-  // 1. 위치 설정
+  const VITE_WEATHER_API_KEY = import.meta.env.VITE_WEATHER_API_KEY;
+
   useEffect(() => {
     navigator.geolocation.getCurrentPosition(
       (pos) => {
-        setLocation({
-          lat: pos.coords.latitude,
-          lon: pos.coords.longitude,
-        });
+        setLocation({ lat: pos.coords.latitude, lon: pos.coords.longitude });
       },
       (err) => {
         console.warn("위치 정보를 가져오지 못했습니다:", err);
@@ -29,33 +27,58 @@ function DateSelector({ onDateSelect, onWeatherFetch }) {
     );
   }, []);
 
-  // 2. 위치가 설정된 후 날씨 가져오기
   useEffect(() => {
     if (location.lat && location.lon) {
-      fetchForecast();
+      fetchForecast5();
+      fetchForecast16();
     }
   }, [location]);
 
-  const fetchForecast = async () => {
+  useEffect(() => {
+    if (forecast5.length > 0 || forecast16.length > 0) {
+      // mount 시점에 오늘 날짜에 해당하는 날씨 가져오기
+      handleChange(new Date());
+    }
+  }, [forecast5, forecast16]);
+
+  const fetchForecast5 = async () => {
     try {
-      const VITE_WEATHER_API_KEY = import.meta.env.VITE_WEATHER_API_KEY;
+      const res = await axios.get(
+        "https://api.openweathermap.org/data/2.5/forecast",
+        {
+          params: {
+            lat: location.lat,
+            lon: location.lon,
+            units: "metric",
+            appid: VITE_WEATHER_API_KEY,
+          },
+        }
+      );
+      console.log("5일 예보 데이터:", res.data);
+      setForecast5(res.data.list);
+    } catch (err) {
+      console.error("5일 예보 API 요청 실패:", err);
+    }
+  };
+
+  const fetchForecast16 = async () => {
+    try {
       const res = await axios.get(
         "https://api.openweathermap.org/data/2.5/forecast/daily",
         {
           params: {
-            lat: location.lat || 37.5665, // 기본값: 서울
-            lon: location.lon || 126.978,
+            lat: location.lat,
+            lon: location.lon,
             cnt: 16,
             units: "metric",
             appid: VITE_WEATHER_API_KEY,
           },
         }
       );
-      console.log("📡 날씨 API 응답:", res.data); // ← 콘솔 출력 추가
-
-      setForecastList(res.data.list);
+      console.log("16일 예보 데이터:", res.data);
+      setForecast16(res.data.list);
     } catch (err) {
-      console.error("날씨 API 요청 실패:", err);
+      console.error("16일 예보 API 요청 실패:", err);
     }
   };
 
@@ -66,18 +89,45 @@ function DateSelector({ onDateSelect, onWeatherFetch }) {
 
     const key = format(date, "yyyy-MM-dd");
     if (weatherCache[key]) {
-      onWeatherFetch(weatherCache[key]); // 캐시 사용
-    } else {
-      const daysDiff = Math.floor(
-        (date.setHours(0, 0, 0, 0) - new Date().setHours(0, 0, 0, 0)) /
-          (1000 * 60 * 60 * 24)
+      onWeatherFetch(weatherCache[key]);
+      return;
+    }
+
+    const today = new Date();
+    const daysDiff = Math.floor(
+      (date.setHours(0, 0, 0, 0) - today.setHours(0, 0, 0, 0)) /
+        (1000 * 60 * 60 * 24)
+    );
+
+    if (daysDiff <= 5) {
+      const targetDateStr = format(date, "yyyy-MM-dd");
+      const entry = forecast5.find((item) =>
+        item.dt_txt?.includes(targetDateStr)
       );
-      const data = forecastList[daysDiff];
+      if (entry) {
+        const weather = {
+          temperature: entry.main.temp,
+          humidity: entry.main.humidity,
+          windSpeed: entry.wind.speed,
+          visibility: entry.visibility ?? 0,
+          solar: entry.solarRadiation ?? 0, // placeholder, API does not provide this directly
+          dewPoint: entry.main.temp - (100 - entry.main.humidity) / 5,
+          rainfall: entry.rain?.["3h"] ?? 0,
+          snowfall: entry.snow?.["3h"] ?? 0,
+        };
+        setWeatherCache((prev) => ({ ...prev, [key]: weather }));
+        onWeatherFetch(weather);
+      }
+    } else {
+      const data = forecast16[daysDiff];
       if (data) {
         const weather = {
           temperature: data.temp.day,
           humidity: data.humidity,
           windSpeed: data.speed,
+          visibility: data.visibility ?? 0, // not typically present
+          solar: data.solarRadiation ?? 0, // placeholder
+          dewPoint: data.temp.day - (100 - data.humidity) / 5,
           rainfall: data.rain ?? 0,
           snowfall: data.snow ?? 0,
         };

--- a/frontend/src/components/PredictionForm.jsx
+++ b/frontend/src/components/PredictionForm.jsx
@@ -13,13 +13,19 @@ function PredictionForm({ onPrediction }) {
   const [visibility, setVisibility] = useState(2000);
   const [solar, setSolar] = useState(0.3);
   const [dewPoint, setDewPoint] = useState(15.2);
-  const [season, setSeason] = useState("Summer"); // 옵션: Spring, Summer, Autumn, Winter
-  const [holiday, setHoliday] = useState(0); // 0 or 1
+  const [season, setSeason] = useState("Summer");
+  const [holiday, setHoliday] = useState(0);
+
+  // ✅ 날씨 데이터 수신 시 업데이트
+  const handleWeatherFetch = ({ temperature, humidity, windSpeed }) => {
+    setTemperature(temperature);
+    setHumidity(humidity);
+    setWindSpeed(windSpeed);
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-
-    const formattedDate = date.toISOString().slice(0, 10); // yyyy-mm-dd
+    const formattedDate = date.toISOString().slice(0, 10);
 
     const inputData = {
       Date: formattedDate,
@@ -46,13 +52,21 @@ function PredictionForm({ onPrediction }) {
 
   return (
     <form onSubmit={handleSubmit}>
-      <DateSelector onDateSelect={setDate} />
+      <DateSelector
+        onDateSelect={setDate}
+        onWeatherFetch={({ temperature, humidity, windSpeed }) => {
+          setTemperature(temperature);
+          setHumidity(humidity);
+          setWindSpeed(windSpeed);
+        }}
+      />
+
       <div>
         시간:{" "}
         <input
           type="number"
           value={hour}
-          onChange={(e) => setHour(Number(e.target.value))}
+          onChange={(e) => setHour(+e.target.value)}
         />
       </div>
       <div>
@@ -60,7 +74,7 @@ function PredictionForm({ onPrediction }) {
         <input
           type="number"
           value={temperature}
-          onChange={(e) => setTemperature(Number(e.target.value))}
+          onChange={(e) => setTemperature(+e.target.value)}
         />
       </div>
       <div>
@@ -68,7 +82,7 @@ function PredictionForm({ onPrediction }) {
         <input
           type="number"
           value={humidity}
-          onChange={(e) => setHumidity(Number(e.target.value))}
+          onChange={(e) => setHumidity(+e.target.value)}
         />
       </div>
       <div>
@@ -76,7 +90,7 @@ function PredictionForm({ onPrediction }) {
         <input
           type="number"
           value={windSpeed}
-          onChange={(e) => setWindSpeed(Number(e.target.value))}
+          onChange={(e) => setWindSpeed(+e.target.value)}
         />
       </div>
       <div>
@@ -84,7 +98,7 @@ function PredictionForm({ onPrediction }) {
         <input
           type="number"
           value={visibility}
-          onChange={(e) => setVisibility(Number(e.target.value))}
+          onChange={(e) => setVisibility(+e.target.value)}
         />
       </div>
       <div>
@@ -92,7 +106,7 @@ function PredictionForm({ onPrediction }) {
         <input
           type="number"
           value={rainfall}
-          onChange={(e) => setRainfall(Number(e.target.value))}
+          onChange={(e) => setRainfall(+e.target.value)}
         />
       </div>
       <div>
@@ -100,7 +114,7 @@ function PredictionForm({ onPrediction }) {
         <input
           type="number"
           value={snowfall}
-          onChange={(e) => setSnowfall(Number(e.target.value))}
+          onChange={(e) => setSnowfall(+e.target.value)}
         />
       </div>
       <div>
@@ -108,7 +122,7 @@ function PredictionForm({ onPrediction }) {
         <input
           type="number"
           value={solar}
-          onChange={(e) => setSolar(Number(e.target.value))}
+          onChange={(e) => setSolar(+e.target.value)}
         />
       </div>
       <div>
@@ -116,7 +130,7 @@ function PredictionForm({ onPrediction }) {
         <input
           type="number"
           value={dewPoint}
-          onChange={(e) => setDewPoint(Number(e.target.value))}
+          onChange={(e) => setDewPoint(+e.target.value)}
         />
       </div>
       <div>
@@ -130,10 +144,7 @@ function PredictionForm({ onPrediction }) {
       </div>
       <div>
         공휴일:
-        <select
-          value={holiday}
-          onChange={(e) => setHoliday(Number(e.target.value))}
-        >
+        <select value={holiday} onChange={(e) => setHoliday(+e.target.value)}>
           <option value={0}>아니오</option>
           <option value={1}>예</option>
         </select>

--- a/frontend/src/components/PredictionForm.jsx
+++ b/frontend/src/components/PredictionForm.jsx
@@ -4,7 +4,7 @@ import axios from "axios";
 
 function PredictionForm({ onPrediction }) {
   const [date, setDate] = useState(new Date());
-  const [hour, setHour] = useState(14);
+  const [hour, setHour] = useState(new Date().getHours());
   const [temperature, setTemperature] = useState(23.5);
   const [humidity, setHumidity] = useState(60);
   const [windSpeed, setWindSpeed] = useState(1.8);
@@ -16,11 +16,19 @@ function PredictionForm({ onPrediction }) {
   const [season, setSeason] = useState("Summer");
   const [holiday, setHoliday] = useState(0);
 
-  // ✅ 날씨 데이터 수신 시 업데이트
-  const handleWeatherFetch = ({ temperature, humidity, windSpeed }) => {
-    setTemperature(temperature);
-    setHumidity(humidity);
-    setWindSpeed(windSpeed);
+  const handleWeatherFetch = (weather) => {
+    setTemperature(weather.temperature);
+    setHumidity(weather.humidity);
+    setWindSpeed(weather.windSpeed);
+    setRainfall(weather.rainfall);
+    setSnowfall(weather.snowfall);
+    setVisibility(weather.visibility);
+    setSolar(weather.solar);
+    setDewPoint(weather.dewPoint);
+
+    // 현재 시간으로 hour 설정
+    const now = new Date();
+    setHour(now.getHours());
   };
 
   const handleSubmit = async (e) => {
@@ -45,6 +53,8 @@ function PredictionForm({ onPrediction }) {
     try {
       const res = await axios.post("/api/predict", inputData);
       onPrediction(res.data.prediction);
+      console.log("input DATA:", inputData);
+      console.log("예측 결과:", res.data);
     } catch (err) {
       console.error("예측 요청 오류:", err);
     }
@@ -54,11 +64,7 @@ function PredictionForm({ onPrediction }) {
     <form onSubmit={handleSubmit}>
       <DateSelector
         onDateSelect={setDate}
-        onWeatherFetch={({ temperature, humidity, windSpeed }) => {
-          setTemperature(temperature);
-          setHumidity(humidity);
-          setWindSpeed(windSpeed);
-        }}
+        onWeatherFetch={handleWeatherFetch}
       />
 
       <div>


### PR DESCRIPTION
#2 
1. 위치 정보 획득
- 브라우저의 navigator.geolocation을 통해 사용자 위치(lat, lon)를 가져옴
- 실패 시 서울(37.5665, 126.978)로 기본값 설정

2. 날씨 데이터 요청
- lat, lon, appid, units=metric 포함하여 API 요청
- 위치 설정 후 자동으로 5일 예보 및 16일 예보 둘 다 요청
- forecast5와 forecast16으로 분리 저장

3. 날짜 선택 시 날씨 추출
- 선택한 날짜가 오늘 기준 5일 이내면 → 5일 예보 데이터 사용
- 6일 이후면 → 16일 예보 데이터 사용
- 각 예보에서 해당 날짜의 데이터를 추출해 기온, 습도, 풍속, 강수량, 적설량, 가시거리, 이슬점, 일사량 등을 계산
- 계산된 결과는 weatherCache에 저장 및 PredictionForm에 전달

4. 캐싱 처리
- 동일 날짜로 여러 번 요청하지 않도록 날짜별로 weatherCache에 저장
- 이미 저장된 경우 API 재호출 없이 캐시된 값 사용